### PR TITLE
Fix container check in item_fiction.js

### DIFF
--- a/js/item_fiction.js
+++ b/js/item_fiction.js
@@ -50,6 +50,7 @@ const projects = [
 ];
 
 const container = document.getElementById("projects-container");
+if (!container) return;
 
 projects.forEach(project => {
   const item = document.createElement("div");


### PR DESCRIPTION
## Summary
- prevent errors when `projects-container` is missing by checking for the container before rendering projects

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68455401467083219a51814694471d49