### PR TITLE
Add basic jsdom test for item_fiction

### DIFF
--- a/js/item_fiction.js
+++ b/js/item_fiction.js
@@ -51,19 +51,22 @@ const projects = [
 
 const container = document.getElementById("projects-container");
 
+// Rendre les vignettes uniquement lorsqu'un conteneur est présent
+if (!container) return;
+
 projects.forEach(project => {
-  const item = document.createElement("div");
-  item.className = "col-6 col-sm-6 col-md-4 col-lg-3";
-  item.innerHTML = `
-    <a href="${project.link}" class="project-item text-decoration-none text-white d-block">
-      <div class="project-item">
-        <img src="${project.image}" alt="Affiche ${project.title}" class="project-image">
-        <div class="project-info">
-          <div class="project-title">${project.title}</div>
-          <div class="project-meta">${project.type} · ${project.duration}</div>
+    const item = document.createElement("div");
+    item.className = "col-6 col-sm-6 col-md-4 col-lg-3";
+    item.innerHTML = `
+      <a href="${project.link}" class="project-item text-decoration-none text-white d-block">
+        <div class="project-item">
+          <img src="${project.image}" alt="Affiche ${project.title}" class="project-image">
+          <div class="project-info">
+            <div class="project-title">${project.title}</div>
+            <div class="project-meta">${project.type} · ${project.duration}</div>
+          </div>
         </div>
-      </div>
-    </a>
-  `;
-  container.appendChild(item);
-});
+      </a>
+    `;
+    container.appendChild(item);
+  });

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,15 @@
+# Tests
+
+Ce répertoire contient un test simple pour `js/item_fiction.js`.
+
+## Exécution
+
+Assurez-vous que le paquet `jsdom` est disponible puis lancez :
+
+```bash
+node tests/item_fiction.test.js
+```
+
+Le test crée une page sans élément `projects-container` et vérifie que le
+script s'exécute sans lever d'exception.
+

--- a/tests/item_fiction.test.js
+++ b/tests/item_fiction.test.js
@@ -1,0 +1,22 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+// HTML without the projects-container element
+const html = '<!DOCTYPE html><html><body></body></html>';
+
+const dom = new JSDOM(html, { runScripts: 'dangerously' });
+
+try {
+  const scriptPath = path.join(__dirname, '../js/item_fiction.js');
+  const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+  const scriptEl = dom.window.document.createElement('script');
+  scriptEl.textContent = scriptContent;
+  dom.window.document.body.appendChild(scriptEl);
+  console.log('Test passed: no exceptions thrown when projects-container is missing.');
+} catch (error) {
+  console.error('Test failed: an exception was thrown.');
+  console.error(error);
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- guard against missing `projects-container` in `item_fiction.js`
- add a jsdom-based test to ensure the script doesn't throw if the container is absent
- document how to run the test
- adjust container check to use early return

## Testing
- `node tests/item_fiction.test.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6845544ee8408321bbd0265ccf47dcf2